### PR TITLE
support const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ fn static_toml2(input: TokenStream2) -> Result<TokenStream2, Error> {
             doc,
             other_attrs,
             visibility,
+            definition,
             ..
         } = static_toml;
 
@@ -143,7 +144,7 @@ fn static_toml2(input: TokenStream2) -> Result<TokenStream2, Error> {
         tokens.push(quote! {
             #(#doc)*
             #auto_doc
-            #visibility static #name: #root_mod::#root_type = #static_tokens;
+            #visibility #definition #name: #root_mod::#root_type = #static_tokens;
 
             #(#other_attrs)*
             #type_tokens

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -38,7 +38,7 @@ impl ToTokens for StaticTomlDefinition {
     fn to_token_stream(&self) -> proc_macro2::TokenStream {
         match self {
             Self::Const(c) => c.to_token_stream(),
-            Self::Static(s) => s.into_token_stream()
+            Self::Static(s) => s.to_token_stream()
         }
     }
 


### PR DESCRIPTION
This will allow you to use const the same way you use static. For example

```rs
static_toml::static_toml! {
    const EXAMPLE = include_toml!("example.toml");
}
```