### PR TITLE
Add Support for the `const` Keyword in Variable Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ const WELCOME_MESSAGE: &str = MESSAGES.info.welcome;
 This will read your TOML file and generate Rust data structures accordingly.
 Now you can access the values from the TOML file with ease.
 
+In addition to using `static`, the `static_toml!` macro also allows the use of 
+`const` for embedding TOML data. 
+This can be particularly useful in scenarios where a constant value is required, 
+such as within const functions or for const generics. 
+To use this feature, simply replace `static` with `const` in the macro call when 
+necessary.
+
 ## Customization Options
 You can configure how the macro should generate data types:
 ```rust

--- a/doc/crate.md
+++ b/doc/crate.md
@@ -163,5 +163,44 @@ static_toml::static_toml! {
 }
 ```
 
+# Using `const`
+While the `static_toml!` macro is named for its primary functionality of 
+statically including TOML files as `static` variables, it also supports the use 
+of `const` variables. 
+This option is provided to accommodate specific use cases where `const` is 
+necessary.
+
+The use of `const` can be crucial in scenarios such as const functions, which 
+can refer to `const` variables but not to `static` variables, and const generics 
+that require `const` values. 
+When deciding between `static` and `const`, it's important to consider the 
+memory usage implications. 
+The `static` keyword is ideal for large TOML files that should only occupy space 
+in the application once, helping to optimize memory usage. 
+In contrast, using `const` could potentially increase the binary size, 
+especially if the same TOML data is reused multiple times. 
+For further details on the `static` keyword in Rust, see the 
+[Rust documentation on `static`](https://doc.rust-lang.org/std/keyword.static.html).
+
+To use `const` within the `static_toml!` macro, simply replace `static` with 
+`const` in the macro call. 
+For example:
+```rust
+static_toml::static_toml! {
+    const MESSAGES = include_toml!("messages.toml");
+}
+```
+
+It's also possible to mix `static` and `const` entries within the same 
+`static_toml!` macro call. 
+However, keep in mind that each identifier must be unique within the same scope. 
+Here's an example of using both `static` and `const` in a single macro call:
+```rust
+static_toml::static_toml! {
+    static MESSAGES = include_toml!("messages.toml");
+    const EXAMPLE = include_toml!("example.toml");
+}
+```
+
 # Implementation Details
 For the specific details, check the documentation for [`static_toml!`].

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -13,8 +13,13 @@ static_toml::static_toml! {
     )]
     #[derive(Debug)]
     static EXAMPLE = include_toml!("example.toml");
+
+    // constant values also work
+    #[derive(Debug)]
+    const MESSAGES = include_toml!("messages.toml");
 }
 
 fn main() {
     dbg!(&EXAMPLE);
+    dbg!(MESSAGES);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,10 @@ fn static_toml2(input: TokenStream2) -> Result<TokenStream2, Error> {
                 .map(|lit_bool| lit_bool.value),
             static_toml.doc.len()
         ) {
-            (None, 0) | (Some(true), _) => toml_tokens::gen_auto_doc(&raw_file_path, &content),
+            (None, 0) | (Some(true), _) => {
+                toml_tokens::gen_auto_doc(&raw_file_path, &content, &static_toml.storage_class)
+            }
+
             (None, _) | (Some(false), _) => Default::default()
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro_error::{abort, abort_call_site, proc_macro_error};
 use quote::{format_ident, quote, ToTokens};
-use syn::{token, LitStr, Token};
+use syn::LitStr;
 use toml::value::{Table, Value};
 
 use crate::parse::{StaticToml, StaticTomlItem, StorageClass};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -208,7 +208,23 @@ mod tests {
     use quote::{format_ident, quote, ToTokens};
     use syn::{parse_quote, LitBool, Token, Visibility};
 
-    use crate::parse::{IncludeTomlToken, StaticToml, EXPECTED_INCLUDE_TOML};
+    use crate::parse::{IncludeTomlToken, StaticToml, StorageClass, EXPECTED_INCLUDE_TOML};
+
+    impl StorageClass {
+        fn is_static(&self) -> bool {
+            match self {
+                StorageClass::Static(_) => true,
+                StorageClass::Const(_) => false
+            }
+        }
+
+        fn is_const(&self) -> bool {
+            match self {
+                StorageClass::Static(_) => false,
+                StorageClass::Const(_) => true
+            }
+        }
+    }
 
     #[test]
     fn parse_include_toml_token() {
@@ -251,6 +267,7 @@ mod tests {
         assert!(images.other_attrs.is_empty());
         assert!(images.derive.is_empty());
         assert!(images.visibility.is_none());
+        assert!(images.storage_class.is_static());
         assert_eq!(images.name, format_ident!("IMAGES"));
         assert_eq!(images.path.value().as_str(), "images.toml");
 
@@ -276,6 +293,7 @@ mod tests {
             config.visibility,
             Some(Visibility::Public(Token![pub](Span2::call_site())))
         );
+        assert!(config.storage_class.is_const());
         assert_eq!(config.name, format_ident!("CONFIG"));
         assert_eq!(config.path.value().as_str(), "config.toml");
 
@@ -300,6 +318,7 @@ mod tests {
             panic!("not a restricted visibility");
         };
         assert!(example.derive.is_empty());
+        assert!(example.storage_class.is_static());
         assert_eq!(example.name, format_ident!("EXAMPLE"));
         assert_eq!(example.path.value().as_str(), "example.toml");
 
@@ -312,6 +331,7 @@ mod tests {
         assert!(basic.other_attrs.is_empty());
         assert!(basic.visibility.is_none());
         assert!(basic.derive.is_empty());
+        assert!(basic.storage_class.is_static());
         assert_eq!(basic.name, format_ident!("BASIC"));
         assert_eq!(basic.path.value().as_str(), "basic.toml");
     }

--- a/src/toml_tokens/mod.rs
+++ b/src/toml_tokens/mod.rs
@@ -15,7 +15,7 @@ use syn::{Attribute, Ident as Ident2};
 use toml::value::Array;
 use toml::Value;
 
-use crate::parse::StaticTomlAttributes;
+use crate::parse::{StaticTomlAttributes, StorageClass};
 
 mod static_tokens;
 mod type_tokens;
@@ -216,8 +216,12 @@ fn is_valid_identifier(input: &str) -> bool {
 }
 
 /// Generate the auto doc comment for the statics.
-pub fn gen_auto_doc(path: &str, content: &str) -> TokenStream2 {
-    let summary = format!("Static inclusion of `{path}`.");
+pub fn gen_auto_doc(path: &str, content: &str, storage_class: &StorageClass) -> TokenStream2 {
+    let storage_class = match storage_class {
+        StorageClass::Static(_) => "Static",
+        StorageClass::Const(_) => "Constant"
+    };
+    let summary = format!("{storage_class} inclusion of `{path}`.");
     quote! {
         #[doc = ""]
         #[doc = #summary]


### PR DESCRIPTION
In #1 @adhami3310 implemented support for the `const` keyword. This takes some ideas from it and expands on it.

This will therefore close #1.